### PR TITLE
Add compatibility with related specs. Created dummy relations for next links.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,43 +39,59 @@ for (const relationId of metadata.relations.keys()) {
 In this section, the extracted fields per class are listed.
 In the case an Object is returned, it can have arbitrary fields that are not listed below.
 
-| Object                | Metadata field      | type          |
-|-----------------------|---------------------|---------------|
-| Collection            | @id                 | string
-|                       | @type               | [ string ]
-|                       | view                | [ URI ] # References a Node object
-|                       | member              | [ URI ]
-|                       | shape               | [ object ]
-|                       | import              | [ URI ]
-|                       | importStream        | [ URI ]
-|                       | conditionalImport   | [ ConditionalImport ]
-| Node                  | @id                 | string
-|                       | @type               | [ string ]
-|                       | search              | [ object ]
-|                       | relation            | [ URI ] # References a Relation object
-|                       | import              | [ object ]
-|                       | importStream        | [ object ]
-|                       | conditionalImport   | [ ConditionalImport ]
-| Relation              | @id                 | string
-|                       | @type               | [ string ]
-|                       | remainingItems      | [ Literal ]
-|                       | path                | [ object ]
-|                       | value               | [ object ]
-|                       | node                | [ object ]
-|                       | import              | [ URI ]
-|                       | importStream        | [ URI ]
-|                       | conditionalImport   | [ ConditionalImport ]
-| ConditionalImport     | path                | [ object ]
-|                       | import              | [ URI ]
-|                       | importStream        | [ URI ]
-| Literal               | @value              | [ string ] 
-|                       | @type               | [ string ]
-|                       | @language           | [ string ]
-| URI                   | @id                 | string
-| object                | @id                 | string
-|                       | <span style="color:red">...</span>                | <span style="color:red">[ any ]</span>
+| Object                | Metadata field      | type                  | referenced object type |
+|-----------------------|---------------------|-----------------------|------------------------|
+| Collection            | @id                 | string                |                        |
+|                       | @type               | [ string ]            |                        |
+|                       | view                | [ URI ]               | Node                   |
+|                       | member              | [ URI ]               | Member                 |
+|                       | shape               | [ Shape ]             |                        |
+|                       | totalItems          | [ Literal ]           |                        |
+|                       | import              | [ URI ]               |                        |
+|                       | importStream        | [ URI ]               |                        |
+|                       | conditionalImport   | [ ConditionalImport ] |                        |
+|                       | ...                 | [ any ]               |                        |
+| Node                  | @id                 | string                |                        |
+|                       | @type               | [ string ]            |                        |
+|                       | relation            | [ URI ]               | Relation               |
+|                       | search              | [ object ]            |                        |
+|                       | retentionPolicy     | [ RetentionPolicy ]   |                        |
+|                       | import              | [ object ]            |                        |
+|                       | importStream        | [ object ]            |                        |
+|                       | conditionalImport   | [ ConditionalImport ] |                        |
+|                       | ...                 | [ any ]               |                        |
+| Relation              | @id                 | string                |                        |      
+|                       | @type               | [ string ]            |                        |
+|                       | remainingItems      | [ Literal ]           |                        |
+|                       | path                | [ object ]            | shacl:propertyPath     |
+|                       | value               | [ object ]            |                        |
+|                       | node                | [ URI ]               | Node                   |
+|                       | import              | [ URI ]               |                        |
+|                       | importStream        | [ URI ]               |                        |
+|                       | conditionalImport   | [ ConditionalImport ] |                        |
+| Member                | ...                 | [ any ]               |                        |
+| Shape                 | ...                 | [ any ]               | shacl:NodeShape / shex:Shape |
+| IriTemplate           | ...                 | [ any ]               | hydra:IriTemplate      |
+| ConditionalImport     | path                | [ object ]            | shacl:propertyPath     |
+|                       | import              | [ URI ]               |                        |
+|                       | importStream        | [ URI ]               |                        |
+| RetentionPolicy       | @type               | [ string ]            |                        |
+|                       | amount              | [ Literal ]           |                        |
+|                       | versionKey          | [ object ]            |                        |
+|                       | path                | [ object ]            | shacl:propertyPath     |
+|                       | value               | [ object ]            |                        |
+| Literal               | @value              | [ string ]            |                        |
+|                       | @type               | [ string ]            |                        |
+|                       | @language           | [ string ]            |                        |
+| URI                   | @id                 | string                |                        |
+| object                | @id                 | string                |                        |
+|                       | ...                 | [ any ]               |                        |
 
 
+```
+Note: Blank node URIs can be returned as a URI. 
+We expect any additional data used in combination with the extracted metadata to be retrieved from the same rdfjs data factory.
+```
 
 ### Examples
 

--- a/src/util/NameSpaces.ts
+++ b/src/util/NameSpaces.ts
@@ -60,6 +60,8 @@ enum aliases {
   dbo = 'http://dbpedia.org/ontology/',
   ex = 'http://example.com/',
   tree = 'https://w3id.org/tree#',
+  ldes = 'https://w3id.org/ldes#',
+  st = 'http://www.w3.org/ns/shapetrees#',
   hydra = 'http://www.w3.org/ns/hydra/core#',
   void = 'http://rdfs.org/ns/void#',
   shacl = 'http://www.w3.org/ns/shacl#',

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -12,25 +12,30 @@ export enum RelationType {
 }
 
 export interface Collection {
-  "@context": any,
+  "@context"?: string | object,
   "@id": string,
-  "view"?: any[],
-  "member"?: any[],
-  "shape"?: any[],
-  "import"?: any[],
-  "importStream"?: any[],
-  "conditionalImport"?: any[],
+  "@type"?: string[],
+  "view"?: URI[],
+  "member"?: Member[],
+  "shape"?: Shape[],
+  "totalItems"?: Literal[],
+  "import"?: URI[],
+  "importStream"?: URI[],
+  "conditionalImport"?: ConditionalImport[],
+  [property: string]: any;
 }
 
 export interface Node {
-  "@context": any,
+  "@context"?: string | object,
   "@id": string,
   "@type"?: string[],
-  "search"?: any[],
-  "relation"?: any[],
-  "import"?: any[],
-  "importStream"?: any[],
-  "conditionalImport"?: any[],
+  "relation"?: URI[], // Note hydra:next / as:next links are added as Relations of type tree:relation with the target node as the target of the next relation
+  "search"?: IriTemplate[],
+  "retentionPolicy"?: RetentionPolicy[],
+  "import"?: URI[],
+  "importStream"?: URI[],
+  "conditionalImport"?: ConditionalImport[],
+  [property: string]: any;
 
 }
 
@@ -38,23 +43,51 @@ export interface Relation {
   "@context": any,
   "@id": string,
   "@type"?: string[],
-  "remainingItems"?: any[],
+  "remainingItems"?: Literal[],
   "path"?: any[],
   "value"?: any[],
-  "node"?: any[],
-  "import"?: any[],
-  "importStream"?: any[],
-  "conditionalImport"?: any[],
+  "node"?: URI[],
+  "import"?: URI[],
+  "importStream"?: URI[],
+  "conditionalImport"?: ConditionalImport[],
 }
 
+export interface Member {
+  "@id"?: string,
+  [property: string]: any;
+}
+
+export interface Shape {
+  "@id"?: string,
+  [property: string]: any;
+}
+
+export interface IriTemplate {
+  "@id"?: string,
+  [property: string]: any;
+}
 export interface ConditionalImport {
   "@id"?: string,
   "import"?: any[],
   "importStream"?: any[],
   "conditionalImport"?: any[],
 }
+
+export interface RetentionPolicy {
+  "@id"?: string,
+  "@type"?: string[],
+  "amount"?: Literal[],
+  "versionKey"?: string[],
+  "path"?: any[],
+  "value"?: any[],
+}
+
 export interface Literal {
   "@value": string,
   "@type"?: string,
   "@language"?: string,
+}
+
+export interface URI {
+  "@id": string,
 }

--- a/tests/MetadataExtraction.test.js
+++ b/tests/MetadataExtraction.test.js
@@ -25,6 +25,7 @@ async function test(turtleString, result, message) {
 async function evaluateMetadataExtraction(input, result) {
   const extractedMetadataPerType = await extractMetadata(input)
   // Check if output is valid JSONLD
+  console.log(result, extractedMetadataPerType)
   for (let type of ['collections', 'nodes', 'relations']) {
     let extractedMapping = extractedMetadataPerType[type]
     let resultMapping = result[type]
@@ -607,9 +608,13 @@ describe('testing elaborate extraction',
     sensorNodes.set("https://streams.datapiloten.be/sensors?page=1", {
       "@context": context,
       "@id": "https://streams.datapiloten.be/sensors?page=1",
-      "relation": [{
-        "@id": "_:b8_b13"
-      }]
+      "relation": [
+        {
+          "@id": "_:b8_b13"
+        }, {
+          "@id": "_:nextRelation-0"
+        }
+      ]
     })
 
     // blank node ids are required to reference the relevant objects
@@ -627,6 +632,14 @@ describe('testing elaborate extraction',
       "value": [{
         "@type": ns.xsd("dateTime"),
         "@value": "2020-06-30T14:48:52.013Z"
+      }]
+    })
+    sensorRelations.set('_:nextRelation-0', {
+      "@context": context,
+      "@id": "_:nextRelation-0",
+      "@type": [ns.tree("Relation")],
+      "node": [{
+        "@id": "https://streams.datapiloten.be/sensors?page=2"
       }]
     })
 


### PR DESCRIPTION
PR to add compatibility from the tree spec to the extraction library.
The predicates of all compatible specs are mapped to their TREE counterparts.
Next links are converted to tree:Relations with a tree:node value of the target link.